### PR TITLE
Encode HTML entities in $text

### DIFF
--- a/lettering/twigextensions/LetteringTwigExtension.php
+++ b/lettering/twigextensions/LetteringTwigExtension.php
@@ -65,7 +65,7 @@ class LetteringTwigExtension extends \Twig_Extension
         if (!$text || strlen($text) === 0 || !method_exists(craft()->lettering, $class)) {
             return $text;
         }
-
+        $text = htmlentities($text);
         $dom = new LetteringDom();
         $dom->loadHTML(mb_convert_encoding('<div id="workingNode">'.$text.'</div>', 'HTML-ENTITIES', $this->encoding));
 


### PR DESCRIPTION
Not sure if this is the best place/approach, but it seems to work for me. I just encode the HTML entities with htmlentities() before they get processed with mb_convert_encoding. Does it make sense to do it this way?
